### PR TITLE
feat: enhance embed handling for all post types

### DIFF
--- a/src/lib/components/PostComponent.svelte
+++ b/src/lib/components/PostComponent.svelte
@@ -89,12 +89,23 @@
 					{post.post.record?.text || ''}
 				</div>
 				
-				<!-- Post media -->
-				<PostMedia embed={post.post.embed} />
-				
-				<!-- Quote post -->
-				{#if post.post.embed?.$type === 'app.bsky.embed.record#view' && post.post.embed.record}
-					<PostQuote quotedPost={post.post.embed.record} />
+				<!-- Handle different embed types -->
+				{#if post.post.embed}
+					{#if post.post.embed.$type === 'app.bsky.embed.recordWithMedia#view'}
+						<!-- Combined media + quote post -->
+						<PostMedia embed={post.post.embed.media} />
+						{#if post.post.embed.record?.record}
+							<PostQuote quotedPost={post.post.embed.record.record} />
+						{/if}
+					{:else if post.post.embed.$type === 'app.bsky.embed.record#view'}
+						<!-- Quote post only -->
+						{#if post.post.embed.record}
+							<PostQuote quotedPost={post.post.embed.record} />
+						{/if}
+					{:else}
+						<!-- Regular media (images, video, external links) -->
+						<PostMedia embed={post.post.embed} />
+					{/if}
 				{/if}
 				
 				<!-- Engagement stats -->

--- a/src/lib/components/PostMedia.svelte
+++ b/src/lib/components/PostMedia.svelte
@@ -99,3 +99,35 @@
 		</div>
 	</div>
 {/if}
+
+<!-- External links -->
+{#if embed?.$type === 'app.bsky.embed.external#view' || embed?.external}
+	{@const external = embed.external || embed}
+	<a 
+		href={external.uri} 
+		target="_blank" 
+		rel="noopener noreferrer"
+		class="mt-3 block border border-base-300 rounded-lg overflow-hidden hover:bg-base-50 transition-colors"
+	>
+		{#if external.thumb}
+			<img 
+				src={external.thumb} 
+				alt={external.title || 'Link preview'}
+				class="w-full h-48 object-cover"
+			/>
+		{/if}
+		<div class="p-3">
+			<div class="text-sm font-semibold text-base-content line-clamp-2">
+				{external.title || 'Untitled'}
+			</div>
+			{#if external.description}
+				<div class="text-xs text-base-content/70 mt-1 line-clamp-2">
+					{external.description}
+				</div>
+			{/if}
+			<div class="text-xs text-blue-600 mt-2">
+				{new URL(external.uri).hostname}
+			</div>
+		</div>
+	</a>
+{/if}


### PR DESCRIPTION
## Summary
- Fixed missing context in posts containing both media and quotes
- Added support for all Bluesky embed types  
- Improved visual hierarchy for complex posts

## Changes
- **RecordWithMedia Support**: Posts that contain both media (images/video) and quoted posts now display both elements properly
- **External Link Previews**: Added rich link preview cards with thumbnail, title, description, and domain
- **Better Embed Type Handling**: Explicitly handles all embed types (recordWithMedia, record, external, images, video)

## Problem Solved
Previously, posts like Paul Frazee's "It was wild" comment would display without the attached CNBC article image and Rose's quoted post, leaving readers without context. This PR ensures all embedded content is properly displayed.

## Test Plan
- [x] Verify posts with recordWithMedia embeds show both media and quote
- [x] Test external link previews render with proper styling
- [x] Confirm regular images and videos still work
- [x] Check quote-only posts display correctly

🤖 Generated with [Claude Code](https://claude.ai/code)