### PR TITLE
fix: add missing DaisyUI plugin to restore component styling

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -1,3 +1,4 @@
 @import 'tailwindcss';
 @plugin '@tailwindcss/forms';
 @plugin '@tailwindcss/typography';
+@plugin 'daisyui';


### PR DESCRIPTION
## Summary
- Adds missing `@plugin 'daisyui'` line to `src/app.css`
- Fixes API demonstration buttons appearing as plain text
- Restores proper DaisyUI component styling throughout the application

## Problem
The DaisyUI plugin was installed in package.json but never properly configured in the CSS, causing all DaisyUI components to render without styling.

## Solution
Added the `@plugin 'daisyui';` line to `src/app.css` to enable DaisyUI component styles.

## Test Plan
- [x] API demonstration buttons now display with proper card styling
- [x] DaisyUI components render with correct colors and layouts
- [x] No breaking changes to existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)